### PR TITLE
Fix issues with "No breakdowns" tweak

### DIFF
--- a/1.3/Patches/Tweak_NoBreakdowns.xml
+++ b/1.3/Patches/Tweak_NoBreakdowns.xml
@@ -12,7 +12,10 @@
 					<xpath>/Defs/ThingDef[not(defName="VPE_NuclearGenerator")]/comps/li[@Class="CompProperties_Breakdownable"]</xpath>
 				</li>
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef/comps[not(*)]</xpath>
+					<!-- Remove all empty comps, as long as they don't have attributes (to avoid bugs). -->
+					<xpath>/Defs/ThingDef/comps[not(*) and not(@*)]</xpath>
+					<!-- Needs to always succeed to prevent errors when there's no empty comps to remove. -->
+					<success>Always</success>
 				</li>
 			</operations>
 		</active>

--- a/1.3/Patches/Tweak_NoBreakdowns.xml
+++ b/1.3/Patches/Tweak_NoBreakdowns.xml
@@ -6,18 +6,8 @@
 			<li>tweak_noBreakdowns</li>
 		</settings>
 		<label>No Breakdowns</label>
-		<active Class="PatchOperationSequence">
-			<operations>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[not(defName="VPE_NuclearGenerator")]/comps/li[@Class="CompProperties_Breakdownable"]</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<!-- Remove all empty comps, as long as they don't have attributes (to avoid bugs). -->
-					<xpath>/Defs/ThingDef/comps[not(*) and not(@*)]</xpath>
-					<!-- Needs to always succeed to prevent errors when there's no empty comps to remove. -->
-					<success>Always</success>
-				</li>
-			</operations>
+		<active Class="PatchOperationRemove">
+			<xpath>/Defs/ThingDef[not(defName="VPE_NuclearGenerator")]/comps/li[@Class="CompProperties_Breakdownable"]</xpath>
 		</active>
 	</Operation>
 

--- a/1.4/Patches/Tweak_NoBreakdowns.xml
+++ b/1.4/Patches/Tweak_NoBreakdowns.xml
@@ -6,18 +6,8 @@
 			<li>tweak_noBreakdowns</li>
 		</settings>
 		
-		<active Class="PatchOperationSequence">
-			<operations>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[not(defName="VPE_NuclearGenerator")]/comps/li[@Class="CompProperties_Breakdownable"]</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<!-- Remove all empty comps, as long as they don't have attributes (to avoid bugs). -->
-					<xpath>/Defs/ThingDef/comps[not(*) and not(@*)]</xpath>
-					<!-- Needs to always succeed to prevent errors when there's no empty comps to remove. -->
-					<success>Always</success>
-				</li>
-			</operations>
+		<active Class="PatchOperationRemove">
+			<xpath>/Defs/ThingDef[not(defName="VPE_NuclearGenerator")]/comps/li[@Class="CompProperties_Breakdownable"]</xpath>
 		</active>
 	</Operation>
 

--- a/1.4/Patches/Tweak_NoBreakdowns.xml
+++ b/1.4/Patches/Tweak_NoBreakdowns.xml
@@ -12,7 +12,10 @@
 					<xpath>/Defs/ThingDef[not(defName="VPE_NuclearGenerator")]/comps/li[@Class="CompProperties_Breakdownable"]</xpath>
 				</li>
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef/comps[not(*)]</xpath>
+					<!-- Remove all empty comps, as long as they don't have attributes (to avoid bugs). -->
+					<xpath>/Defs/ThingDef/comps[not(*) and not(@*)]</xpath>
+					<!-- Needs to always succeed to prevent errors when there's no empty comps to remove. -->
+					<success>Always</success>
 				</li>
 			</operations>
 		</active>

--- a/1.5/Patches/Tweak_NoBreakdowns.xml
+++ b/1.5/Patches/Tweak_NoBreakdowns.xml
@@ -6,18 +6,8 @@
 			<li>Tweak_NoBreakdowns</li>
 		</settings>
 		
-		<active Class="PatchOperationSequence">
-			<operations>
-				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef[not(defName="VPE_NuclearGenerator")]/comps/li[@Class="CompProperties_Breakdownable"]</xpath>
-				</li>
-				<li Class="PatchOperationRemove">
-					<!-- Remove all empty comps, as long as they don't have attributes (to avoid bugs). -->
-					<xpath>/Defs/ThingDef/comps[not(*) and not(@*)]</xpath>
-					<!-- Needs to always succeed to prevent errors when there's no empty comps to remove. -->
-					<success>Always</success>
-				</li>
-			</operations>
+		<active Class="PatchOperationRemove">
+			<xpath>/Defs/ThingDef[not(defName="VPE_NuclearGenerator")]/comps/li[@Class="CompProperties_Breakdownable"]</xpath>
 		</active>
 	</Operation>
 

--- a/1.5/Patches/Tweak_NoBreakdowns.xml
+++ b/1.5/Patches/Tweak_NoBreakdowns.xml
@@ -12,7 +12,10 @@
 					<xpath>/Defs/ThingDef[not(defName="VPE_NuclearGenerator")]/comps/li[@Class="CompProperties_Breakdownable"]</xpath>
 				</li>
 				<li Class="PatchOperationRemove">
-					<xpath>/Defs/ThingDef/comps[not(*)]</xpath>
+					<!-- Remove all empty comps, as long as they don't have attributes (to avoid bugs). -->
+					<xpath>/Defs/ThingDef/comps[not(*) and not(@*)]</xpath>
+					<!-- Needs to always succeed to prevent errors when there's no empty comps to remove. -->
+					<success>Always</success>
 				</li>
 			</operations>
 		</active>


### PR DESCRIPTION
Currently, the tweak will remove all `CompProperties_Breakdownable` from comps, followed by removing all empty comps.

This causes issues with vanilla game, DLCs, and some mods. This happens due to removing of the comp field while the field had useful attributes applied to it.

`Toxalope` has an empty comp list with `Inherit="False"` attribute set. Removing that causes the toxalope to inherit comps from boomalope (and thus start producing chemfuel).

`ShuttleCrashed` (and its children) have similar issue, where the inherited comps would result in it having 2 sets of comps of the same type. This causes errors during loading (if a crashed shuttle is active/falling, possibly while the quest is not accepted yet as well).

This also happens with `AncientCryptosleepPod`, but I have not investigated the implications of it inheriting comps from its parent.

This PR slightly changes the patch - only removing empty comps that also have no attributes. This also required setting `success` to `Always`, as in vanilla there will be no ThingDef with empty comps (that don't use `Inherit="True"`).

An alternative approach would be to completely skip the removal of empty comps and let the game handle the empty list itself. However, I've decided to expand the approach the mod already took.

If needed, I could change if anything needs changes/remove this change from older mod versions.